### PR TITLE
basic version toggle

### DIFF
--- a/lib/consumer_supervisor.ex
+++ b/lib/consumer_supervisor.ex
@@ -18,6 +18,10 @@ defmodule QuiqupElixirKafka.ConsumerSupervisor do
 
   @impl true
   def init(child_specs) do
+    System.version() |> version_init(child_specs)
+  end
+
+  defp version_init("1.4.5", child_specs)
     import Supervisor.Spec
 
     {kafka_ex_con_group, _start_link, args} = hd(child_specs).start
@@ -34,10 +38,20 @@ defmodule QuiqupElixirKafka.ConsumerSupervisor do
     {:ok, %State{}}
   end
 
+  defp version_init("1.6.0", child_specs) do
+    DynamicSupervisor.start_link(strategy: :one_for_one, name: @dynamic_supervisor)
+
+    for child_spec <- child_specs do
+      Process.send(self(), {:start_child, child_spec}, [])
+    end
+
+    {:ok, %State{}}
+  end
+
   @impl true
   def handle_info({:start_child, child_spec}, %State{refs: refs}) do
     Logger.info("#{__MODULE__} Starting child consumer:#{inspect(child_spec)}")
-    case Supervisor.start_child(@dynamic_supervisor, []) do
+    case System.version() |> version_case(child_spec) do
       {:ok, pid} ->
         Logger.info("#{__MODULE__} monitoring #{inspect(child_spec)} at #{inspect(pid)}")
         ref = Process.monitor(pid)
@@ -57,6 +71,9 @@ defmodule QuiqupElixirKafka.ConsumerSupervisor do
         {:noreply, %State{refs: refs}}
     end
   end
+
+  defp version_case("1.4.5", _child_spec), do: Supervisor.start_child(@dynamic_supervisor, [])
+  defp version_case("1.6.0", child_spec), do: DynamicSupervisor.start_child(@dynamic_supervisor, child_spec)
 
   @impl true
   def handle_info({:DOWN, ref, :process, _pid, _reason}, %State{refs: refs}) do


### PR DESCRIPTION
This takes the code from master, and merges into the fixes made in `elixir-1.4.5` (https://github.com/quiqupltd/QuiqupElixirKafka/pull/1) to toggle between both versions, that way we don't need to keep a branch for the 1.4.5 version.

Is limited to exact versions tho!